### PR TITLE
getNext() is not defined.

### DIFF
--- a/lib/dataStructures/stackQueue.js
+++ b/lib/dataStructures/stackQueue.js
@@ -32,7 +32,7 @@ stackQueue.prototype.clear = function() {
 };
 
 stackQueue.prototype.peek = function() {
-  return this.isEmpty() ? null : this.getNext();
+  return this.isEmpty() ? null : this.list.start;
 };
 
 module.exports = stackQueue;


### PR DESCRIPTION
Not sure if a new function is necessary to get the next item on the top of the stack. Might be easier to just refer to list.start.