### PR TITLE
Use a stack instead of a queue for DFS

### DIFF
--- a/lib/algorithms/4-searching/depthFirstSearch.js
+++ b/lib/algorithms/4-searching/depthFirstSearch.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var Queue = require('../../../lib/dataStructures/queue.js');
+var Stack = require('../../../lib/dataStructures/stack.js');
 
 var depthFirstSearch = function(root, matches) {
-  var nodeQueue = new Queue();
+  var nodeStack = new Stack();
 
   var found = function(node) {
     if (node === null) { return false; }
 
     if (!node.visited) {
       node.visited = true;
-      nodeQueue.push(node);
+      nodeStack.push(node);
     }
 
     return matches(node.data);
@@ -20,8 +20,8 @@ var depthFirstSearch = function(root, matches) {
     return true;
   }
 
-  while (!nodeQueue.isEmpty()) {
-    var node = nodeQueue.pop();
+  while (!nodeStack.isEmpty()) {
+    var node = nodeStack.pop();
 
     if(found(node.left)) {
       return true;

--- a/spec/algo/4-searching/depthFirstSearch.spec.js
+++ b/spec/algo/4-searching/depthFirstSearch.spec.js
@@ -1,7 +1,7 @@
 var depthFirstSearch = require("../../../lib/algorithms/4-searching/depthFirstSearch.js");
 var bst = require("../../../lib/dataStructures/binarySearchTree.js");
 
-describe('Given a binary tree containing the value 16, determine if the depth first search', function () {
+describe('Given a binary tree containing the value 8, determine if the depth first search', function () {
     var balanced;
     beforeEach(function() {
       balanced = new bst();
@@ -14,8 +14,8 @@ describe('Given a binary tree containing the value 16, determine if the depth fi
       balanced.add(16);
     });
 
-  it('can find the value 16 in the tree', function () {
-    expect(depthFirstSearch(balanced.head, function(value) { return value === 16 })).toBe(true);
+  it('can find the value 8 in the tree', function () {
+    expect(depthFirstSearch(balanced.head, function(value) { return value === 8 })).toBe(true);
   });
 
   it('cannot find the value 11', function () {
@@ -23,16 +23,16 @@ describe('Given a binary tree containing the value 16, determine if the depth fi
   });
 
   it('the order of search is correct', function () {
-    var matcher = { matcher: function(value) { return value === 16 }};
+    var matcher = { matcher: function(value) { return value === 8 }};
     spyOn(matcher, "matcher").and.callThrough();
 
     expect(depthFirstSearch(balanced.head, matcher.matcher)).toBe(true);
     expect(matcher.matcher).toHaveBeenCalledWith(10);
     expect(matcher.matcher).toHaveBeenCalledWith(5);
     expect(matcher.matcher).toHaveBeenCalledWith(15);
-    expect(matcher.matcher).toHaveBeenCalledWith(2);
-    expect(matcher.matcher).toHaveBeenCalledWith(8);
     expect(matcher.matcher).toHaveBeenCalledWith(12);
     expect(matcher.matcher).toHaveBeenCalledWith(16);
+    expect(matcher.matcher).toHaveBeenCalledWith(2);
+    expect(matcher.matcher).toHaveBeenCalledWith(8);
   });
 });


### PR DESCRIPTION
Updated the DFS implementation to use a stack instead of a queue (BFS uses a queue). Also updated the tests.