### PR TITLE
Resolve removeHead() problem when the array length is 1

### DIFF
--- a/lib/dataStructures/binaryHeap.js
+++ b/lib/dataStructures/binaryHeap.js
@@ -82,8 +82,10 @@ function removeHead() {
   const headNode = this.array[0];
   const tailNode = this.array.pop();
 
-  this.array[0] = tailNode;
-  this.bubbleDown(0, tailNode);
+  if (this.array.length) {
+    this.array[0] = tailNode;
+    this.bubbleDown(0, tailNode);
+  }
 
   return headNode;
 }


### PR DESCRIPTION
Without the fix, removeHead() does not remove the head node when this.array.length is 1. Executing "this.array[0] = tailNode" adds back the headNode in that case. Btw, thanks for the helpful blog post on this file.