### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ As well as the following algorithms:
 * Shuffle (Fisher–Yates)
 * Smallest Enclosing Circle
 
-##Usage
+## Usage
 
 If you want access to these data structures in your project, include this package.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
